### PR TITLE
SourceInterface::getLabel() returns a non-empty string

### DIFF
--- a/src/Model/AbstractSource.php
+++ b/src/Model/AbstractSource.php
@@ -10,6 +10,7 @@ abstract class AbstractSource implements SourceInterface
      * @param non-empty-string $id
      * @param non-empty-string $userId
      * @param non-empty-string $type
+     * @param non-empty-string $label
      * @param null|int<0, max> $deletedAt
      */
     public function __construct(

--- a/src/Model/SourceInterface.php
+++ b/src/Model/SourceInterface.php
@@ -21,6 +21,9 @@ interface SourceInterface
      */
     public function getType(): string;
 
+    /**
+     * @return non-empty-string
+     */
     public function getLabel(): string;
 
     /**


### PR DESCRIPTION
Fixes #158