### PR TITLE
GitSourceClientInterface::create() allows empty hostUrl, path

### DIFF
--- a/src/GitSourceClientInterface.php
+++ b/src/GitSourceClientInterface.php
@@ -27,8 +27,6 @@ interface GitSourceClientInterface
 
     /**
      * @param non-empty-string  $token
-     * @param non-empty-string  $hostUrl
-     * @param non-empty-string  $path
      * @param ?non-empty-string $credentials
      *
      * @throws ClientExceptionInterface


### PR DESCRIPTION
Fixes #164